### PR TITLE
Fix continuous integration target branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   lint:


### PR DESCRIPTION
This fixes the continuous integration not running on the main branch because the configuration was copied from a project using a master branch.